### PR TITLE
Implement types for command components

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run rustfmt
-        run: find src -name '*.rs' -exec rustfmt --check '{}' +
+        run: find src tests -name '*.rs' -exec rustfmt --check '{}' +
 
   unit-tests:
     name: Unit tests

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -6,6 +6,7 @@ use std::net;
 
 mod command;
 mod reply;
+mod types;
 
 pub struct Connection {
     reader: Box<dyn io::BufRead>,

--- a/src/connection/types/channel.rs
+++ b/src/connection/types/channel.rs
@@ -1,0 +1,450 @@
+use super::{ParseError, ServerMask};
+use std::result::Result;
+use std::str::FromStr;
+
+const LOCAL_PREFIX: char = '&';
+const SAFE_PREFIX: char = '!';
+const NO_MODE_PREFIX: char = '+';
+const PUBLIC_PREFIX: char = '#';
+
+/// A channel is a named group of one or more users which will all receive
+/// messages addressed to that channel. According to RFC 2812:
+///
+/// ```text
+/// channel    =  ( "#" / "+" / ( "!" channelid ) / "&" ) chanstring
+///               [ ":" chanstring ]
+/// chanstring =  %x01-07 / %x08-09 / %x0B-0C / %x0E-1F / %x21-2B
+/// chanstring =/ %x2D-39 / %x3B-FF
+///                 ; any octet except NUL, BELL, CR, LF, " ", "," and ":"
+/// channelid  = 5( %x41-5A / digit )   ; 5( A-Z / 0-9 )
+/// ```
+///
+/// The RFC does a poor job of explaining, but the ':' character precedes a
+/// channel mask, that being a server mask to which the channel is restricted.
+#[derive(PartialEq, Debug)]
+pub struct Channel {
+    channel_type: ChannelType,
+    channel_name: ChannelName,
+    server_mask: Option<ServerMask>,
+}
+
+impl FromStr for Channel {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        let (raw, server_mask) = if let Some(index) = raw.find(':') {
+            (&raw[..index], Some(raw[index + 1..].parse()?))
+        } else {
+            (raw, None)
+        };
+
+        if raw.len() < 2 || raw.len() > 50 {
+            Err(ParseError::new("Channel"))
+        } else {
+            if raw.starts_with(SAFE_PREFIX) && raw.len() > 6 && raw.is_char_boundary(6) {
+                Ok(Channel {
+                    channel_type: ChannelType::Safe(raw[1..6].parse()?),
+                    channel_name: raw[6..].parse()?,
+                    server_mask,
+                })
+            } else {
+                Ok(Channel {
+                    channel_type: match raw.chars().nth(0) {
+                        Some(LOCAL_PREFIX) => ChannelType::Local,
+                        Some(NO_MODE_PREFIX) => ChannelType::NoMode,
+                        Some(PUBLIC_PREFIX) => ChannelType::Public,
+                        _ => return Err(ParseError::new("Channel")),
+                    },
+                    channel_name: raw[1..].parse()?,
+                    server_mask,
+                })
+            }
+        }
+    }
+}
+
+impl From<Channel> for String {
+    fn from(channel: Channel) -> String {
+        let mut result = String::from(channel.channel_type);
+        result.push_str(&String::from(channel.channel_name)[..]);
+        if let Some(server_mask) = channel.server_mask {
+            result.push(':');
+            result.push_str(&String::from(server_mask)[..]);
+        }
+        result
+    }
+}
+
+/// The type of a channel, also referred to as its namespace.
+///
+/// - `#` is public, shared among all servers on a network.
+/// - `&` is local, not shared with any server
+/// - `+` is public but does not support modes such as +o and +v
+/// - `!` is public but "safe" and is prefixed with a server-generated channel
+///   ID to mitigate name collisions between servers
+#[derive(PartialEq, Debug)]
+pub enum ChannelType {
+    Local,           // Prefix: &
+    Safe(ChannelID), // Prefix: ![A-Z0-9]{5}
+    NoMode,          // Prefix: +
+    Public,          // Prefix: #
+}
+
+impl FromStr for ChannelType {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        match (raw.len(), raw.chars().nth(0)) {
+            (1, Some(LOCAL_PREFIX)) => Ok(ChannelType::Local),
+            (1, Some(NO_MODE_PREFIX)) => Ok(ChannelType::NoMode),
+            (1, Some(PUBLIC_PREFIX)) => Ok(ChannelType::Public),
+            (6, Some(SAFE_PREFIX)) => {
+                if let Ok(channel_id) = raw[1..].to_string().parse() {
+                    Ok(ChannelType::Safe(channel_id))
+                } else {
+                    Err(ParseError::new("ChannelType"))
+                }
+            }
+            _ => Err(ParseError::new("ChannelType")),
+        }
+    }
+}
+
+impl From<ChannelType> for String {
+    fn from(channel_type: ChannelType) -> String {
+        match channel_type {
+            ChannelType::Local => LOCAL_PREFIX.to_string(),
+            ChannelType::NoMode => NO_MODE_PREFIX.to_string(),
+            ChannelType::Public => PUBLIC_PREFIX.to_string(),
+            ChannelType::Safe(channel_id) => {
+                let mut result = SAFE_PREFIX.to_string();
+                result.push_str(&String::from(channel_id)[..]);
+                result
+            }
+        }
+    }
+}
+
+/// The 5-digit ID attached to a "safe" channel name.
+///
+/// ```text
+/// channelid  = 5( %x41-5A / digit )   ; 5( A-Z / 0-9 )
+/// ```
+///
+/// ```text
+/// The channel identifier is a function of the time.  The current time
+/// (as defined under UNIX by the number of seconds elapsed since
+/// 00:00:00 GMT, January 1, 1970) is converted in a string of five (5)
+/// characters using the following base:
+/// "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890" (each character has a decimal
+/// value starting from 0 for 'A' to 35 for '0').
+///
+/// The channel identifier therefore has a periodicity of 36^5 seconds
+/// (about 700 days).
+/// ```
+///
+/// (Yes, this is backwards from normal base-x encoding.)
+#[derive(PartialEq, Debug)]
+pub struct ChannelID(String);
+
+impl FromStr for ChannelID {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        if raw.len() != 5 {
+            println!("{:?}", raw);
+            Err(ParseError::new("ChannelID"))
+        } else {
+            if raw.contains(|c: char| !c.is_ascii_uppercase() && !c.is_ascii_digit()) {
+                Err(ParseError::new("ChannelID"))
+            } else {
+                Ok(Self(raw.to_string()))
+            }
+        }
+    }
+}
+
+impl From<ChannelID> for String {
+    fn from(channel_id: ChannelID) -> String {
+        channel_id.0
+    }
+}
+
+/// The name/"chanstring" part of a channel identifier.
+///
+/// ```text
+/// chanstring =  %x01-07 / %x08-09 / %x0B-0C / %x0E-1F / %x21-2B
+/// chanstring =/ %x2D-39 / %x3B-FF
+///                 ; any octet except NUL, BELL, CR, LF, " ", "," and ":"
+/// ```
+#[derive(PartialEq, Debug)]
+pub struct ChannelName(String);
+
+impl FromStr for ChannelName {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        if raw.len() < 1 || raw.contains(&['\x00', '\x07', '\r', '\n', ' ', ',', ':'][..]) {
+            Err(ParseError::new("ChannelName"))
+        } else {
+            Ok(Self(raw.to_string()))
+        }
+    }
+}
+
+impl From<ChannelName> for String {
+    fn from(channel_name: ChannelName) -> String {
+        channel_name.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_channel() {
+        assert!("".parse::<Channel>().is_err());
+        assert!("#".parse::<Channel>().is_err());
+        assert!("+".parse::<Channel>().is_err());
+        assert!("&".parse::<Channel>().is_err());
+        assert!("🥔️".parse::<Channel>().is_err());
+        assert!("!ABCDE".parse::<Channel>().is_err());
+        assert!("!ABCD🥔️".parse::<Channel>().is_err());
+        assert!("noprefix".parse::<Channel>().is_err());
+        assert!("#too:many:colons".parse::<Channel>().is_err());
+        assert!("&new\nline".parse::<Channel>().is_err());
+        assert!("+carriage\rreturn".parse::<Channel>().is_err());
+        assert!("!ABCDEnull\0char".parse::<Channel>().is_err());
+        assert!("#ding\x07dong".parse::<Channel>().is_err());
+        assert!("& space".parse::<Channel>().is_err());
+        assert!("+comma,".parse::<Channel>().is_err());
+        assert!("!12345:colon".parse::<Channel>().is_err());
+        assert!("#01234567890123456789012345678901234567890123456789"
+            .parse::<Channel>()
+            .is_err());
+    }
+
+    #[test]
+    fn valid_channel() {
+        assert_eq!(
+            Channel {
+                channel_type: ChannelType::Public,
+                channel_name: ChannelName("mypublic".to_string()),
+                server_mask: None,
+            },
+            "#mypublic"
+                .parse::<Channel>()
+                .expect("#mypublic should be valid")
+        );
+        assert_eq!(
+            Channel {
+                channel_type: ChannelType::Local,
+                channel_name: ChannelName("my_local".to_string()),
+                server_mask: None,
+            },
+            "&my_local"
+                .parse::<Channel>()
+                .expect("&my_local should be valid")
+        );
+        assert_eq!(
+            Channel {
+                channel_type: ChannelType::NoMode,
+                channel_name: ChannelName("my-no-mode".to_string()),
+                server_mask: Some(
+                    "*.example.com"
+                        .parse()
+                        .expect("Unable to parse server mask")
+                ),
+            },
+            "+my-no-mode:*.example.com"
+                .parse::<Channel>()
+                .expect("+my-no-mode:*.example.com should be valid")
+        );
+        assert_eq!(
+            Channel {
+                channel_type: ChannelType::Safe(ChannelID("ABC12".to_string())),
+                channel_name: ChannelName("3".to_string()),
+                server_mask: None,
+            },
+            "!ABC123"
+                .parse::<Channel>()
+                .expect("!ABC123 should be valid")
+        );
+        assert_eq!(
+            Channel {
+                channel_type: ChannelType::Public,
+                channel_name: ChannelName(
+                    "0123456789012345678901234567890123456789012345678".to_string()
+                ),
+                server_mask: None,
+            },
+            "#0123456789012345678901234567890123456789012345678"
+                .parse::<Channel>()
+                .expect("A 50-char channel name should be valid")
+        );
+        assert_eq!(
+            Channel {
+                channel_type: ChannelType::Local,
+                channel_name: ChannelName("🥔️".to_string()),
+                server_mask: None,
+            },
+            "&🥔️"
+                .parse::<Channel>()
+                .expect("A UTF-8 channel name should be valid")
+        );
+    }
+
+    #[test]
+    fn invalid_channel_type() {
+        assert!("".parse::<ChannelType>().is_err());
+        assert!("#a".parse::<ChannelType>().is_err());
+        assert!("*".parse::<ChannelType>().is_err());
+        assert!("🥔️".parse::<ChannelType>().is_err());
+        assert!("#ABCDE".parse::<ChannelType>().is_err());
+        assert!("!ABCD🥔️".parse::<ChannelType>().is_err());
+    }
+
+    #[test]
+    fn valid_channel_type() {
+        assert_eq!(
+            ChannelType::Public,
+            "#".parse::<ChannelType>()
+                .expect("The # character should be valid")
+        );
+        assert_eq!(
+            ChannelType::Local,
+            "&".parse::<ChannelType>()
+                .expect("The & character should be valid")
+        );
+        assert_eq!(
+            ChannelType::NoMode,
+            "+".parse::<ChannelType>()
+                .expect("The + character should be valid")
+        );
+        assert_eq!(
+            ChannelType::Safe(ChannelID("123YZ".to_string())),
+            "!123YZ"
+                .parse::<ChannelType>()
+                .expect("The ! character should be valid when followed by 5 chars")
+        );
+    }
+
+    #[test]
+    fn invalid_channel_id() {
+        assert!("".parse::<ChannelID>().is_err());
+        assert!("1234".parse::<ChannelType>().is_err());
+        assert!("123456".parse::<ChannelType>().is_err());
+        assert!("🥔️".parse::<ChannelType>().is_err());
+        assert!("1234🥔️".parse::<ChannelType>().is_err());
+        assert!("!ABCDE️".parse::<ChannelType>().is_err());
+        assert!("abcde️".parse::<ChannelType>().is_err());
+    }
+
+    #[test]
+    fn valid_channel_id() {
+        assert_eq!(
+            ChannelID("12345".to_string()),
+            "12345"
+                .parse::<ChannelID>()
+                .expect("A numeric channel ID should be valid")
+        );
+        assert_eq!(
+            ChannelID("ABXYZ".to_string()),
+            "ABXYZ"
+                .parse::<ChannelID>()
+                .expect("An uppercase channel ID should be valid")
+        );
+    }
+
+    #[test]
+    fn invalid_channel_name() {
+        assert!("".parse::<ChannelName>().is_err());
+        assert!("new\nline".parse::<ChannelName>().is_err());
+        assert!("carriage\rreturn".parse::<ChannelName>().is_err());
+        assert!("null\0char".parse::<ChannelName>().is_err());
+        assert!("ding\x07dong".parse::<ChannelName>().is_err());
+        assert!(" space".parse::<ChannelName>().is_err());
+        assert!("comma,".parse::<ChannelName>().is_err());
+        assert!("co:on".parse::<ChannelName>().is_err());
+    }
+
+    #[test]
+    fn valid_channel_name() {
+        assert_eq!(
+            ChannelName("mychannel".to_string()),
+            "mychannel"
+                .parse::<ChannelName>()
+                .expect("\"mychannel\" should be a valid channel name")
+        );
+        assert_eq!(
+            ChannelName("#".to_string()),
+            "#".parse::<ChannelName>()
+                .expect("\"#\" should be a valid channel name")
+        );
+        assert_eq!(
+            ChannelName("🥔️".to_string()),
+            "🥔️"
+                .parse::<ChannelName>()
+                .expect("\"🥔️\" should be a valid channel name")
+        );
+        assert_eq!(
+            ChannelName("\"".to_string()),
+            "\"".parse::<ChannelName>()
+                .expect("\"\\\"️\" should be a valid channel name")
+        );
+    }
+
+    #[test]
+    fn into_string() {
+        assert_eq!(
+            "mychan".to_string(),
+            String::from(ChannelName("mychan".to_string())),
+        );
+        assert_eq!(
+            "VWXYZ".to_string(),
+            String::from(ChannelID("VWXYZ".to_string())),
+        );
+
+        assert_eq!("#".to_string(), String::from(ChannelType::Public));
+        assert_eq!("&".to_string(), String::from(ChannelType::Local));
+        assert_eq!("+".to_string(), String::from(ChannelType::NoMode));
+        assert_eq!(
+            "!12345".to_string(),
+            String::from(ChannelType::Safe(ChannelID("12345".to_string())))
+        );
+
+        assert_eq!(
+            "#mychan".to_string(),
+            String::from(Channel {
+                channel_name: ChannelName("mychan".to_string()),
+                channel_type: ChannelType::Public,
+                server_mask: None,
+            })
+        );
+        assert_eq!(
+            "&localchan".to_string(),
+            String::from(Channel {
+                channel_name: ChannelName("localchan".to_string()),
+                channel_type: ChannelType::Local,
+                server_mask: None,
+            })
+        );
+        assert_eq!(
+            "+nomode:example.com".to_string(),
+            String::from(Channel {
+                channel_name: ChannelName("nomode".to_string()),
+                channel_type: ChannelType::NoMode,
+                server_mask: Some("example.com".parse().unwrap()),
+            })
+        );
+        assert_eq!(
+            "!12345safemode".to_string(),
+            String::from(Channel {
+                channel_name: ChannelName("safemode".to_string()),
+                channel_type: ChannelType::Safe(ChannelID("12345".to_string())),
+                server_mask: None,
+            })
+        )
+    }
+}

--- a/src/connection/types/errors.rs
+++ b/src/connection/types/errors.rs
@@ -1,0 +1,23 @@
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub struct ParseError(&'static str);
+
+impl ParseError {
+    pub fn new(struct_name: &'static str) -> Self {
+        ParseError(struct_name)
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Unable to parse component: {}", self)
+    }
+}
+
+impl Error for ParseError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}

--- a/src/connection/types/host.rs
+++ b/src/connection/types/host.rs
@@ -1,0 +1,195 @@
+use super::ParseError;
+pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::result::Result;
+use std::str::FromStr;
+
+/// A hostname or IP address.
+#[derive(PartialEq, Debug)]
+pub enum Host {
+    Hostaddr(IpAddr),
+    Hostname(Hostname),
+}
+
+impl FromStr for Host {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        if let Ok(ipaddr) = raw.parse() {
+            Ok(Host::Hostaddr(ipaddr))
+        } else if let Ok(hostname) = raw.parse() {
+            Ok(Host::Hostname(hostname))
+        } else {
+            Err(ParseError::new("Host"))
+        }
+    }
+}
+
+impl From<Host> for String {
+    fn from(host: Host) -> String {
+        match host {
+            Host::Hostaddr(ip_addr) => ip_addr.to_string(),
+            Host::Hostname(hostname) => String::from(hostname),
+        }
+    }
+}
+
+#[derive(PartialEq, Debug)]
+pub struct Servername(String);
+
+impl FromStr for Servername {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        name_from_string(raw)
+            .map(|s| Self(s))
+            .ok_or(ParseError::new("Servername"))
+    }
+}
+
+impl From<Servername> for String {
+    fn from(servername: Servername) -> String {
+        servername.0
+    }
+}
+
+#[derive(PartialEq, Debug)]
+pub struct Hostname(String);
+
+impl FromStr for Hostname {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        name_from_string(raw)
+            .map(|s| Self(s))
+            .ok_or(ParseError::new("Hostname"))
+    }
+}
+
+impl From<Hostname> for String {
+    fn from(hostname: Hostname) -> String {
+        hostname.0
+    }
+}
+
+fn name_from_string(raw: &str) -> Option<String> {
+    for raw_part in raw.split('.') {
+        if raw_part.len() < 1
+            || !raw_part.starts_with(|c: char| c.is_ascii_alphanumeric())
+            || !raw_part.ends_with(|c: char| c.is_ascii_alphanumeric())
+            || raw_part.contains(|c: char| !c.is_ascii_alphanumeric() && c != '-')
+        {
+            return None;
+        }
+    }
+
+    Some(raw.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_chars() {
+        assert!("abc.d\nf.ghi".parse::<Host>().is_err());
+        assert!("abc.d🥔️f.ghi".parse::<Host>().is_err());
+        assert!("abc.d f.ghi".parse::<Host>().is_err());
+        assert!("abc.-ef.ghi".parse::<Host>().is_err());
+        assert!("abc.de-.ghi".parse::<Host>().is_err());
+        assert!("".parse::<Host>().is_err());
+    }
+
+    #[test]
+    fn invalid_dot_placement() {
+        assert!("abc..ghi".parse::<Host>().is_err());
+        assert!(".a".parse::<Host>().is_err());
+
+        // All non-relative hostnames technically terminate with a trailing dot,
+        // but the RFC disagrees.
+        assert!("abc.def.ghi.".parse::<Host>().is_err());
+    }
+
+    #[test]
+    fn valid() {
+        assert_eq!(
+            Host::Hostname(Hostname("abcdefghi".to_string())),
+            "abcdefghi"
+                .parse::<Host>()
+                .expect("Hostname without dots should be valid")
+        );
+        assert_eq!(
+            Host::Hostname(Hostname("abc.d-f.ghi".to_string())),
+            "abc.d-f.ghi"
+                .parse::<Host>()
+                .expect("Dotted hostname should be valid")
+        );
+    }
+
+    #[test]
+    fn ipv4() {
+        assert_eq!(
+            Host::Hostaddr("1.2.3.4".parse().unwrap()),
+            "1.2.3.4"
+                .parse::<Host>()
+                .expect("Expect host mask to accept an IPv4 address")
+        )
+    }
+
+    #[test]
+    fn ipv6() {
+        assert_eq!(
+            Host::Hostaddr("::1".parse().unwrap()),
+            "::1"
+                .parse::<Host>()
+                .expect("Expect host mask to accept an IPv6 address")
+        );
+        assert_eq!(
+            Host::Hostaddr("2001:db8::ff00:42:8329".parse().unwrap()),
+            "2001:db8::ff00:42:8329"
+                .parse::<Host>()
+                .expect("Expect host mask to accept an IPv6 address")
+        );
+        assert_eq!(
+            Host::Hostaddr("2001:0db8:0000:0000:0000:ff00:0042:8329".parse().unwrap()),
+            "2001:0db8:0000:0000:0000:ff00:0042:8329"
+                .parse::<Host>()
+                .expect("Expect host mask to accept an IPv6 address")
+        );
+    }
+
+    #[test]
+    fn valid_server_and_host_name() {
+        assert_eq!(
+            Servername("abc.def.ghi".to_string()),
+            "abc.def.ghi"
+                .parse::<Servername>()
+                .expect("Failed to accept a valid server name")
+        );
+        assert_eq!(
+            Hostname("abc.def.ghi".to_string()),
+            "abc.def.ghi"
+                .parse::<Hostname>()
+                .expect("Failed to accept a valid hostname")
+        );
+    }
+
+    #[test]
+    fn into_string() {
+        assert_eq!(
+            "1.2.3.4".to_string(),
+            String::from(Host::Hostaddr("1.2.3.4".parse::<IpAddr>().unwrap()))
+        );
+        assert_eq!(
+            "abc.def.ghi".to_string(),
+            String::from(Host::Hostname(Hostname("abc.def.ghi".to_string())))
+        );
+        assert_eq!(
+            "abc.def.ghi".to_string(),
+            String::from(Hostname("abc.def.ghi".to_string()))
+        );
+        assert_eq!(
+            "abc.def.ghi".to_string(),
+            String::from(Servername("abc.def.ghi".to_string()))
+        );
+    }
+}

--- a/src/connection/types/key.rs
+++ b/src/connection/types/key.rs
@@ -1,0 +1,83 @@
+use super::ParseError;
+use std::result::Result;
+use std::str::FromStr;
+
+/// A password restricting access to a channel. According to RFC 2812:
+///
+/// ```text
+/// key        =  1*23( %x01-05 / %x07-08 / %x0C / %x0E-1F / %x21-7F )
+///                 ; any 7-bit US_ASCII character,
+///                 ; except NUL, CR, LF, FF, h/v TABs, and " "
+/// ```
+///
+/// Note that the formal notation excludes the ACK character (\x06) rather than
+/// FF (\x0c) as the comment indicates. This implementation treats the formal
+/// notation as authoritative.
+#[derive(PartialEq, Debug)]
+pub struct Key(String);
+
+impl FromStr for Key {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        if raw.len() < 1
+            || raw.len() > 23
+            || !raw.is_ascii()
+            || raw.contains(&['\x00', '\x06', '\x09', '\x0a', '\x0b', '\x0d', '\x20'][..])
+        {
+            Err(ParseError::new("Key"))
+        } else {
+            Ok(Self(raw.to_string()))
+        }
+    }
+}
+
+impl From<Key> for String {
+    fn from(key: Key) -> String {
+        key.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrong_length() {
+        assert!("".parse::<Key>().is_err());
+        assert!("abcdefghijklmnopqrstuvwx".parse::<Key>().is_err());
+    }
+
+    #[test]
+    fn invalid_characters() {
+        assert!("null\0".parse::<Key>().is_err());
+        assert!("carriage\rreturn".parse::<Key>().is_err());
+        assert!("line\nfeed".parse::<Key>().is_err());
+        assert!(" space".parse::<Key>().is_err());
+        assert!("tab\t".parse::<Key>().is_err());
+        assert!("vertical\x0btab".parse::<Key>().is_err());
+        assert!("acknowledge\x06".parse::<Key>().is_err());
+        assert!("potat🥔️".parse::<Key>().is_err());
+    }
+
+    #[test]
+    fn success() {
+        assert_eq!(
+            Key("a".to_string()),
+            "a".parse::<Key>()
+                .expect("1-character string should be accepted.")
+        );
+
+        assert_eq!(
+            Key("0123456789abcdeABCDE~!#".to_string()),
+            "0123456789abcdeABCDE~!#"
+                .parse::<Key>()
+                .expect("23-character string should be accepted.")
+        );
+    }
+
+    #[test]
+    fn into_string() {
+        assert_eq!("a".to_string(), String::from(Key("a".to_string())))
+    }
+}

--- a/src/connection/types/mod.rs
+++ b/src/connection/types/mod.rs
@@ -1,8 +1,10 @@
 pub use self::key::Key;
+pub use self::nickname::Nickname;
 pub use self::user::User;
 
 pub use self::errors::ParseError;
 
 mod errors;
 mod key;
+mod nickname;
 mod user;

--- a/src/connection/types/mod.rs
+++ b/src/connection/types/mod.rs
@@ -1,0 +1,6 @@
+pub use self::key::Key;
+
+pub use self::errors::ParseError;
+
+mod errors;
+mod key;

--- a/src/connection/types/mod.rs
+++ b/src/connection/types/mod.rs
@@ -1,5 +1,6 @@
 pub use self::key::Key;
 pub use self::nickname::Nickname;
+pub use self::target_mask::{HostMask, ServerMask, TargetMask};
 pub use self::user::User;
 
 pub use self::errors::ParseError;
@@ -7,4 +8,5 @@ pub use self::errors::ParseError;
 mod errors;
 mod key;
 mod nickname;
+mod target_mask;
 mod user;

--- a/src/connection/types/mod.rs
+++ b/src/connection/types/mod.rs
@@ -1,6 +1,7 @@
 pub use self::channel::{Channel, ChannelID, ChannelName, ChannelType};
 pub use self::host::{Host, Hostname, IpAddr, Ipv4Addr, Ipv6Addr, Servername};
 pub use self::key::Key;
+pub use self::msg_target::{MsgTarget, MsgTo};
 pub use self::nickname::Nickname;
 pub use self::target_mask::{HostMask, ServerMask, TargetMask};
 pub use self::user::User;
@@ -11,6 +12,7 @@ mod channel;
 mod errors;
 mod host;
 mod key;
+mod msg_target;
 mod nickname;
 mod target_mask;
 mod user;

--- a/src/connection/types/mod.rs
+++ b/src/connection/types/mod.rs
@@ -1,6 +1,8 @@
 pub use self::key::Key;
+pub use self::user::User;
 
 pub use self::errors::ParseError;
 
 mod errors;
 mod key;
+mod user;

--- a/src/connection/types/mod.rs
+++ b/src/connection/types/mod.rs
@@ -1,3 +1,4 @@
+pub use self::channel::{Channel, ChannelID, ChannelName, ChannelType};
 pub use self::host::{Host, Hostname, IpAddr, Ipv4Addr, Ipv6Addr, Servername};
 pub use self::key::Key;
 pub use self::nickname::Nickname;
@@ -6,6 +7,7 @@ pub use self::user::User;
 
 pub use self::errors::ParseError;
 
+mod channel;
 mod errors;
 mod host;
 mod key;

--- a/src/connection/types/mod.rs
+++ b/src/connection/types/mod.rs
@@ -1,3 +1,4 @@
+pub use self::host::{Host, Hostname, IpAddr, Ipv4Addr, Ipv6Addr, Servername};
 pub use self::key::Key;
 pub use self::nickname::Nickname;
 pub use self::target_mask::{HostMask, ServerMask, TargetMask};
@@ -6,6 +7,7 @@ pub use self::user::User;
 pub use self::errors::ParseError;
 
 mod errors;
+mod host;
 mod key;
 mod nickname;
 mod target_mask;

--- a/src/connection/types/msg_target.rs
+++ b/src/connection/types/msg_target.rs
@@ -1,0 +1,321 @@
+use super::{Channel, Host, Nickname, ParseError, Servername, TargetMask, User};
+use std::borrow::Borrow;
+use std::result::Result;
+use std::str::FromStr;
+
+#[derive(PartialEq, Debug)]
+pub struct MsgTarget(Vec<MsgTo>);
+
+impl FromStr for MsgTarget {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        let mut targets = Vec::<MsgTo>::new();
+        for msg_to in raw.split(',') {
+            targets.push(msg_to.parse()?);
+        }
+        Ok(Self(targets))
+    }
+}
+
+impl From<MsgTarget> for String {
+    fn from(msg_target: MsgTarget) -> String {
+        msg_target
+            .0
+            .into_iter()
+            .map(|a| String::from(a))
+            .collect::<Vec<String>>()
+            .join(",")
+    }
+}
+
+impl Borrow<Vec<MsgTo>> for MsgTarget {
+    fn borrow(&self) -> &Vec<MsgTo> {
+        &self.0
+    }
+}
+
+/// A single target of a message such as PRIVMSG. This can take many different
+/// forms:
+///
+/// ```text
+/// msgto      =  channel / ( user [ "%" host ] "@" servername )
+/// msgto      =/ ( user "%" host ) / targetmask
+/// msgto      =/ nickname / ( nickname "!" user "@" host )
+/// channel    =  ( "#" / "+" / ( "!" channelid ) / "&" ) chanstring
+///               [ ":" chanstring ]
+/// servername =  hostname
+/// host       =  hostname / hostaddr
+/// hostname   =  shortname *( "." shortname )
+/// shortname  =  ( letter / digit ) *( letter / digit / "-" )
+///               *( letter / digit )
+///                 ; as specified in RFC 1123 [HNAME]
+/// hostaddr   =  ip4addr / ip6addr
+/// ip4addr    =  1*3digit "." 1*3digit "." 1*3digit "." 1*3digit
+/// ip6addr    =  1*hexdigit 7( ":" 1*hexdigit )
+/// ip6addr    =/ "0:0:0:0:0:" ( "0" / "FFFF" ) ":" ip4addr
+/// nickname   =  ( letter / special ) *8( letter / digit / special / "-" )
+/// targetmask =  ( "$" / "#" ) mask
+///                 ; see details on allowed masks in section 3.3.1
+/// chanstring =  %x01-07 / %x08-09 / %x0B-0C / %x0E-1F / %x21-2B
+/// chanstring =/ %x2D-39 / %x3B-FF
+///                 ; any octet except NUL, BELL, CR, LF, " ", "," and ":"
+/// channelid  = 5( %x41-5A / digit )   ; 5( A-Z / 0-9 )
+/// user       =  1*( %x01-09 / %x0B-0C / %x0E-1F / %x21-3F / %x41-FF )
+///                 ; any octet except NUL, CR, LF, " " and "@"
+/// key        =  1*23( %x01-05 / %x07-08 / %x0C / %x0E-1F / %x21-7F )
+///                 ; any 7-bit US_ASCII character,
+///                 ; except NUL, CR, LF, FF, h/v TABs, and " "
+/// letter     =  %x41-5A / %x61-7A       ; A-Z / a-z
+/// digit      =  %x30-39                 ; 0-9
+/// hexdigit   =  digit / "A" / "B" / "C" / "D" / "E" / "F"
+/// special    =  %x5B-60 / %x7B-7D
+///                  ; "[", "]", "\", "`", "_", "^", "{", "|", "}"
+/// ```
+///
+/// This syntax leaves plenty of room for ambiguity, so the following precedence
+/// is used by the parser:
+///
+/// - "#rando.chan" => public channel or server mask? channel
+/// - "#*.com" => public channel or server mask? mask
+/// - "#user@example.com" => public channel or user@servername? channel
+/// - "user%host@example.com" => is the username "user" or "user%host"? "user"
+/// - "user%host" => is the username "user%host" or "user"? "user"
+/// - "user%host%host" => what is even happening here? invalid, reject
+#[derive(PartialEq, Debug)]
+pub enum MsgTo {
+    Channel(Channel),
+    Nickname(Nickname),
+    NicknameUserHost(Nickname, User, Host), // nickname!user@host
+    TargetMask(TargetMask),
+    UserHost(User, Host),                       // user%host
+    UserHostServername(User, Host, Servername), // user%host@servername
+    UserServername(User, Servername),           // user@servername
+}
+
+impl FromStr for MsgTo {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        if raw.starts_with('#') && raw.contains(&['*', '?'][..]) {
+            if let Ok(target_mask) = raw.parse() {
+                return Ok(MsgTo::TargetMask(target_mask));
+            }
+        }
+
+        if let Ok(channel) = raw.parse() {
+            Ok(MsgTo::Channel(channel))
+        } else if let Ok(target_mask) = raw.parse() {
+            Ok(MsgTo::TargetMask(target_mask))
+        } else if let Ok(nickname) = raw.parse() {
+            Ok(MsgTo::Nickname(nickname))
+        } else {
+            match &raw.matches(&['!', '@', '%'][..]).collect::<String>()[..] {
+                "!@" => {
+                    let parts: Vec<&str> = raw.split(&['!', '@'][..]).collect();
+                    Ok(MsgTo::NicknameUserHost(
+                        parts[0].parse()?,
+                        parts[1].parse()?,
+                        parts[2].parse()?,
+                    ))
+                }
+                "%@" => {
+                    let parts: Vec<&str> = raw.split(&['%', '@'][..]).collect();
+                    Ok(MsgTo::UserHostServername(
+                        parts[0].parse()?,
+                        parts[1].parse()?,
+                        parts[2].parse()?,
+                    ))
+                }
+                "%" => {
+                    let parts: Vec<&str> = raw.split('%').collect();
+                    Ok(MsgTo::UserHost(parts[0].parse()?, parts[1].parse()?))
+                }
+                "@" => {
+                    let parts: Vec<&str> = raw.split('@').collect();
+                    Ok(MsgTo::UserServername(parts[0].parse()?, parts[1].parse()?))
+                }
+                _ => Err(ParseError::new("MsgTo")),
+            }
+        }
+    }
+}
+
+impl From<MsgTo> for String {
+    fn from(msg_to: MsgTo) -> String {
+        match msg_to {
+            MsgTo::Channel(channel) => String::from(channel),
+            MsgTo::Nickname(nickname) => String::from(nickname),
+            MsgTo::NicknameUserHost(nickname, user, host) => [
+                &String::from(nickname),
+                "!",
+                &String::from(user),
+                "@",
+                &String::from(host),
+            ]
+            .join(""),
+            MsgTo::TargetMask(target_mask) => String::from(target_mask),
+            MsgTo::UserHost(user, host) => [String::from(user), String::from(host)].join("%"),
+            MsgTo::UserHostServername(user, host, servername) => [
+                &String::from(user),
+                "%",
+                &String::from(host),
+                "@",
+                &String::from(servername),
+            ]
+            .join(""),
+            MsgTo::UserServername(user, servername) => {
+                [String::from(user), String::from(servername)].join("@")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_msgtarget() {
+        assert!("".parse::<MsgTarget>().is_err());
+    }
+
+    #[test]
+    fn valid_msgtarget() {
+        assert_eq!(
+            MsgTarget(vec![MsgTo::Nickname("mynick".parse().unwrap())]),
+            "mynick".parse::<MsgTarget>().unwrap()
+        );
+        assert_eq!(
+            MsgTarget(vec![MsgTo::Channel("#mychan".parse().unwrap())]),
+            "#mychan".parse::<MsgTarget>().unwrap()
+        );
+        assert_eq!(
+            MsgTarget(vec![MsgTo::TargetMask("$my.target.mask".parse().unwrap())]),
+            "$my.target.mask".parse::<MsgTarget>().unwrap()
+        );
+        assert_eq!(
+            MsgTarget(vec![
+                MsgTo::Channel("#channel".parse().unwrap()),
+                MsgTo::Nickname("nickname".parse().unwrap()),
+                MsgTo::NicknameUserHost("NUHnickname".parse().unwrap(), "NUHuser".parse().unwrap(), "NUHhost".parse().unwrap()),
+                MsgTo::TargetMask("$target.mask".parse().unwrap()),
+                MsgTo::UserHost("UHuser".parse().unwrap(), "UHhost".parse().unwrap()),
+                MsgTo::UserHostServername("UHSuser".parse().unwrap(), "UHShost".parse().unwrap(), "UHSservername".parse().unwrap()),
+                MsgTo::UserServername("USuser".parse().unwrap(), "USservername".parse().unwrap()),
+            ]),
+            "#channel,nickname,NUHnickname!NUHuser@NUHhost,$target.mask,UHuser%UHhost,UHSuser%UHShost@UHSservername,USuser@USservername".parse::<MsgTarget>().unwrap()
+        );
+    }
+
+    #[test]
+    fn invalid_msgto() {
+        assert!("".parse::<MsgTo>().is_err());
+        assert!("user%host%host".parse::<MsgTo>().is_err());
+        assert!("🥔️".parse::<MsgTo>().is_err());
+    }
+
+    #[test]
+    fn valid_msgto() {
+        assert_eq!(
+            MsgTo::Nickname("mynick".parse().unwrap()),
+            "mynick".parse::<MsgTo>().unwrap()
+        );
+        assert_eq!(
+            MsgTo::NicknameUserHost(
+                "mynick".parse().unwrap(),
+                "user".parse().unwrap(),
+                "host".parse().unwrap()
+            ),
+            "mynick!user@host".parse::<MsgTo>().unwrap()
+        );
+        assert_eq!(
+            MsgTo::UserServername("user".parse().unwrap(), "servername".parse().unwrap()),
+            "user@servername".parse::<MsgTo>().unwrap()
+        );
+        assert_eq!(
+            MsgTo::Nickname("mynick".parse().unwrap()),
+            "mynick".parse::<MsgTo>().unwrap()
+        );
+        assert_eq!(
+            MsgTo::Channel("#rando.chan".parse().unwrap()),
+            "#rando.chan".parse::<MsgTo>().unwrap()
+        );
+        assert_eq!(
+            MsgTo::TargetMask("#*.com".parse().unwrap()),
+            "#*.com".parse::<MsgTo>().unwrap()
+        );
+        assert_eq!(
+            MsgTo::Channel("#user@example.com".parse().unwrap()),
+            "#user@example.com".parse::<MsgTo>().unwrap()
+        );
+        assert_eq!(
+            MsgTo::UserHostServername(
+                "user".parse().unwrap(),
+                "host".parse().unwrap(),
+                "example.com".parse().unwrap()
+            ),
+            "user%host@example.com".parse::<MsgTo>().unwrap()
+        );
+        assert_eq!(
+            MsgTo::UserHost("user".parse().unwrap(), "host".parse().unwrap()),
+            "user%host".parse::<MsgTo>().unwrap()
+        );
+    }
+
+    #[test]
+    fn into_string() {
+        assert_eq!(
+            "#mychan".to_string(),
+            String::from(MsgTo::Channel("#mychan".parse().unwrap()))
+        );
+        assert_eq!(
+            "mynick".to_string(),
+            String::from(MsgTo::Nickname("mynick".parse().unwrap()))
+        );
+        assert_eq!(
+            "nickname!user@host".to_string(),
+            String::from(MsgTo::NicknameUserHost(
+                "nickname".parse().unwrap(),
+                "user".parse().unwrap(),
+                "host".parse().unwrap()
+            ))
+        );
+        assert_eq!(
+            "$target.mask".to_string(),
+            String::from(MsgTo::TargetMask("$target.mask".parse().unwrap()))
+        );
+        assert_eq!(
+            "user%host".to_string(),
+            String::from(MsgTo::UserHost(
+                "user".parse().unwrap(),
+                "host".parse().unwrap()
+            ))
+        );
+        assert_eq!(
+            "user%host@servername".to_string(),
+            String::from(MsgTo::UserHostServername(
+                "user".parse().unwrap(),
+                "host".parse().unwrap(),
+                "servername".parse().unwrap()
+            ))
+        );
+        assert_eq!(
+            "user@servername".to_string(),
+            String::from(MsgTo::UserServername(
+                "user".parse().unwrap(),
+                "servername".parse().unwrap()
+            ))
+        );
+
+        assert_eq!(
+            "#channel1,nick1,#channel2,nick2".to_string(),
+            String::from(MsgTarget(vec![
+                MsgTo::Channel("#channel1".parse().unwrap()),
+                MsgTo::Nickname("nick1".parse().unwrap()),
+                MsgTo::Channel("#channel2".parse().unwrap()),
+                MsgTo::Nickname("nick2".parse().unwrap()),
+            ]))
+        );
+    }
+}

--- a/src/connection/types/nickname.rs
+++ b/src/connection/types/nickname.rs
@@ -1,0 +1,153 @@
+use super::ParseError;
+use std::result::Result;
+use std::str::FromStr;
+
+/// The nickname by which a user is primarily known. According to RFC 2812:
+///
+/// ```text
+/// nickname   =  ( letter / special ) *8( letter / digit / special / "-" )
+/// letter     =  %x41-5A / %x61-7A       ; A-Z / a-z
+/// digit      =  %x30-39                 ; 0-9
+/// special    =  %x5B-60 / %x7B-7D
+///                  ; "[", "]", "\", "`", "_", "^", "{", "|", "}"
+/// ```
+///
+/// Note that this notation limits nicknames to 9 characters, but the RFC
+/// elsewhere recommends supporting longer nicknames for forwards compatibility.
+/// We currently enforce no upper bound.
+#[derive(PartialEq, Debug)]
+pub struct Nickname(String);
+
+impl FromStr for Nickname {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        if raw.len() < 1 || !raw.is_ascii() {
+            Err(ParseError::new("Nickname"))
+        } else if let '\x41'..='\x7d' = raw.chars().nth(0).unwrap() {
+            if raw[1..].contains(|c: char| {
+                if let '\x2d' | '\x30'..='\x39' | '\x41'..='\x7d' = c {
+                    false
+                } else {
+                    true
+                }
+            }) {
+                Err(ParseError::new("Nickname"))
+            } else {
+                Ok(Self(raw.to_string()))
+            }
+        } else {
+            Err(ParseError::new("Nickname"))
+        }
+    }
+}
+
+impl From<Nickname> for String {
+    fn from(nickname: Nickname) -> String {
+        nickname.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Nickname;
+
+    #[test]
+    fn too_short() {
+        assert!("".parse::<Nickname>().is_err());
+    }
+
+    #[test]
+    fn not_ascii() {
+        assert!("potat🥔️".parse::<Nickname>().is_err());
+    }
+
+    #[test]
+    fn invalid_chars() {
+        assert!("2hot4u".parse::<Nickname>().is_err());
+        //assert!("nickn@me".parse::<Nickname>().is_err());
+        assert!("-minus".parse::<Nickname>().is_err());
+        assert!("spaced out".parse::<Nickname>().is_err());
+        assert!("new\nline".parse::<Nickname>().is_err());
+    }
+
+    #[test]
+    fn valid() {
+        assert_eq!(
+            Nickname("a".to_string()),
+            "a".parse::<Nickname>()
+                .expect("Single-character nickname should be accepted.")
+        );
+        assert_eq!(
+            Nickname("n-name".to_string()),
+            "n-name"
+                .parse::<Nickname>()
+                .expect("Hyphen after the first character should be accepted.")
+        );
+        assert_eq!(
+            Nickname("I2hot4u".to_string()),
+            "I2hot4u"
+                .parse::<Nickname>()
+                .expect("Numerals after first character should be accepted.")
+        );
+        assert_eq!(
+            Nickname("ABCDEFGHI".to_string()),
+            "ABCDEFGHI"
+                .parse::<Nickname>()
+                .expect("Uppercase characters should be accepted.")
+        );
+        assert_eq!(
+            Nickname("JKLMNOPQR".to_string()),
+            "JKLMNOPQR"
+                .parse::<Nickname>()
+                .expect("Uppercase characters should be accepted.")
+        );
+        assert_eq!(
+            Nickname("STUVWXYZ0".to_string()),
+            "STUVWXYZ0"
+                .parse::<Nickname>()
+                .expect("Uppercase characters and numerals should be accepted.")
+        );
+        assert_eq!(
+            Nickname("abcdefghi".to_string()),
+            "abcdefghi"
+                .parse::<Nickname>()
+                .expect("Lowercase characters should be accepted.")
+        );
+        assert_eq!(
+            Nickname("jklmnopqr".to_string()),
+            "jklmnopqr"
+                .parse::<Nickname>()
+                .expect("Lowercase characters should be accepted.")
+        );
+        assert_eq!(
+            Nickname("stuvwxyz1".to_string()),
+            "stuvwxyz1"
+                .parse::<Nickname>()
+                .expect("Lowercase characters and numerals should be accepted.")
+        );
+        assert_eq!(
+            Nickname("x23456789".to_string()),
+            "x23456789"
+                .parse::<Nickname>()
+                .expect("Numerals should be accepted.")
+        );
+        assert_eq!(
+            Nickname("[]\\`_^{|}".to_string()),
+            "[]\\`_^{|}"
+                .parse::<Nickname>()
+                .expect("Special characters should be accepted.")
+        );
+        assert_eq!(
+            Nickname("abcdefghijklmnopqrstuvwxyz".to_string()),
+            "abcdefghijklmnopqrstuvwxyz"
+                .parse::<Nickname>()
+                .expect("Strings longer than 9 characters should be accepted.")
+        );
+    }
+
+    #[test]
+    fn into_string() {
+        assert_eq!("a".to_string(), String::from(Nickname("a".to_string())));
+    }
+}

--- a/src/connection/types/target_mask.rs
+++ b/src/connection/types/target_mask.rs
@@ -1,0 +1,258 @@
+use super::ParseError;
+use std::result::Result;
+use std::str::FromStr;
+
+const HOST_PREFIX: char = '#';
+const SERVER_PREFIX: char = '$';
+
+/// A mask used to reference multiple servers or hosts. According to RFC 2812:
+///
+/// ```text
+/// targetmask =  ( "$" / "#" ) mask
+///                 ; see details on allowed masks in section 3.3.1
+/// servername =  hostname
+/// hostname   =  shortname *( "." shortname )
+/// shortname  =  ( letter / digit ) *( letter / digit / "-" )
+///               *( letter / digit )
+///                 ; as specified in RFC 1123 [HNAME]
+/// letter     =  %x41-5A / %x61-7A       ; A-Z / a-z
+/// digit      =  %x30-39                 ; 0-9
+/// ```
+///
+/// ```text
+/// The <msgtarget> parameter may also be a host mask (#<mask>) or server
+/// mask ($<mask>).  In both cases the server will only send the PRIVMSG
+/// to those who have a server or host matching the mask.  The mask MUST
+/// have at least 1 (one) "." in it and no wildcards following the last
+/// ".".  This requirement exists to prevent people sending messages to
+/// "#*" or "$*", which would broadcast to all users.  Wildcards are the
+/// '*' and '?'  characters.  This extension to the PRIVMSG command is
+/// only available to operators.
+/// ```
+///
+/// It's worth noting that the syntax listed implicitly covers IPv4 addresses but
+/// not IPv6. This is a faithful implementation of the standard.
+#[derive(PartialEq, Debug)]
+pub enum TargetMask {
+    Host(HostMask),     // #xyz
+    Server(ServerMask), // $xyz
+}
+
+impl FromStr for TargetMask {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        match raw.chars().nth(0) {
+            Some(HOST_PREFIX) => Ok(TargetMask::Host(raw[1..].parse()?)),
+            Some(SERVER_PREFIX) => Ok(TargetMask::Server(raw[1..].parse()?)),
+            _ => Err(ParseError::new("TargetMask")),
+        }
+    }
+}
+
+impl From<TargetMask> for String {
+    fn from(target_mask: TargetMask) -> String {
+        match target_mask {
+            TargetMask::Host(host_mask) => {
+                let mut result = HOST_PREFIX.to_string();
+                result.push_str(&String::from(host_mask)[..]);
+                result
+            }
+            TargetMask::Server(server_mask) => {
+                let mut result = SERVER_PREFIX.to_string();
+                result.push_str(&String::from(server_mask)[..]);
+                result
+            }
+        }
+    }
+}
+
+#[derive(PartialEq, Debug)]
+pub struct HostMask(String);
+
+impl FromStr for HostMask {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        mask_from_string(raw)
+            .map(|s| Self(s))
+            .ok_or(ParseError::new("HostMask"))
+    }
+}
+
+impl From<HostMask> for String {
+    fn from(host_mask: HostMask) -> String {
+        host_mask.0
+    }
+}
+
+#[derive(PartialEq, Debug)]
+pub struct ServerMask(String);
+
+impl FromStr for ServerMask {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        mask_from_string(raw)
+            .map(|s| Self(s))
+            .ok_or(ParseError::new("ServerMask"))
+    }
+}
+
+impl From<ServerMask> for String {
+    fn from(server_mask: ServerMask) -> String {
+        server_mask.0
+    }
+}
+
+fn mask_from_string(raw: &str) -> Option<String> {
+    if raw.len() > 2
+        && raw.is_ascii()
+        && raw.contains('.')
+        && !raw.split('.').last()?.contains(&['*', '?'][..])
+    {
+        for raw_part in raw.split('.') {
+            if raw_part.len() < 1
+                || !raw_part
+                    .starts_with(|c: char| c.is_ascii_alphanumeric() || c == '*' || c == '?')
+                || !raw_part.ends_with(|c: char| c.is_ascii_alphanumeric() || c == '*' || c == '?')
+                || raw_part.contains(|c: char| {
+                    !c.is_ascii_alphanumeric() && c != '*' && c != '?' && c != '-'
+                })
+            {
+                return None;
+            }
+        }
+
+        Some(raw.to_string())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_chars() {
+        assert!("#abc.d\nf.ghi".parse::<TargetMask>().is_err());
+        assert!("$abc.d🥔️f.ghi".parse::<TargetMask>().is_err());
+        assert!("#abc.d f.ghi".parse::<TargetMask>().is_err());
+        assert!("$abc.-ef.ghi".parse::<TargetMask>().is_err());
+        assert!("#abc.de-.ghi".parse::<TargetMask>().is_err());
+        assert!("$".parse::<TargetMask>().is_err());
+    }
+
+    #[test]
+    fn invalid_prefix() {
+        assert!("!abc.def.ghi".parse::<TargetMask>().is_err());
+        assert!("abc.def.ghi".parse::<TargetMask>().is_err());
+    }
+
+    #[test]
+    fn wildcard_in_last_group() {
+        assert!("#abc.def.g*i".parse::<TargetMask>().is_err());
+    }
+
+    #[test]
+    fn invalid_dot_placement() {
+        assert!("#abcdefghi".parse::<TargetMask>().is_err());
+        assert!("#abc..ghi".parse::<TargetMask>().is_err());
+        assert!("#.a".parse::<TargetMask>().is_err());
+
+        // All non-relative hostnames technically terminate with a trailing dot,
+        // but the RFC disagrees.
+        assert!("#abc.def.ghi.".parse::<TargetMask>().is_err());
+    }
+
+    #[test]
+    fn valid() {
+        assert_eq!(
+            TargetMask::Host(HostMask("abc.def.ghi".to_string())),
+            "#abc.def.ghi"
+                .parse::<TargetMask>()
+                .expect("Explicit host mask should be valid.")
+        );
+        assert_eq!(
+            TargetMask::Server(ServerMask("a-c.d-f.g-i".to_string())),
+            "$a-c.d-f.g-i"
+                .parse::<TargetMask>()
+                .expect("Explicit server mask should be valid.")
+        );
+        assert_eq!(
+            TargetMask::Host(HostMask("abc.*.ghi".to_string())),
+            "#abc.*.ghi"
+                .parse::<TargetMask>()
+                .expect("Host mask with wildcard should be valid.")
+        );
+        assert_eq!(
+            TargetMask::Server(ServerMask("???.*.ghi".to_string())),
+            "$???.*.ghi"
+                .parse::<TargetMask>()
+                .expect("Server mask with multiple wildcards should be valid.")
+        );
+    }
+
+    #[test]
+    fn ipv4() {
+        assert_eq!(
+            TargetMask::Host(HostMask("1.2.3.4".to_string())),
+            "#1.2.3.4"
+                .parse::<TargetMask>()
+                .expect("Expect host mask to accept an IPv4 address.")
+        )
+    }
+
+    #[test]
+    fn ipv6() {
+        // Sadly, IPv6 isn't supported according to the RFC.
+        assert!("$::1".parse::<TargetMask>().is_err());
+        assert!("#2001:db8::ff00:42:8329".parse::<TargetMask>().is_err());
+        assert!("$2001:0db8:0000:0000:0000:ff00:0042:8329"
+            .parse::<TargetMask>()
+            .is_err());
+    }
+
+    #[test]
+    fn invalid_server_and_host_mask() {
+        assert!("#abc.def.ghi".parse::<HostMask>().is_err());
+        assert!("$a-c.d-f.g-i".parse::<ServerMask>().is_err());
+    }
+
+    #[test]
+    fn valid_server_and_host_mask() {
+        assert_eq!(
+            ServerMask("abc.def.ghi".to_string()),
+            "abc.def.ghi"
+                .parse::<ServerMask>()
+                .expect("Expect server mask to accept a valid hostname.")
+        );
+        assert_eq!(
+            HostMask("abc.*.ghi".to_string()),
+            "abc.*.ghi"
+                .parse::<HostMask>()
+                .expect("Expect host mask to accept a valid hostname.")
+        );
+    }
+
+    #[test]
+    fn into_string() {
+        assert_eq!(
+            "$abc.def.ghi".to_string(),
+            String::from(TargetMask::Server(ServerMask("abc.def.ghi".to_string())))
+        );
+        assert_eq!(
+            "#abc.def.ghi".to_string(),
+            String::from(TargetMask::Host(HostMask("abc.def.ghi".to_string())))
+        );
+        assert_eq!(
+            "abc.def.ghi".to_string(),
+            String::from(HostMask("abc.def.ghi".to_string()))
+        );
+        assert_eq!(
+            "abc.def.ghi".to_string(),
+            String::from(ServerMask("abc.def.ghi".to_string()))
+        );
+    }
+}

--- a/src/connection/types/user.rs
+++ b/src/connection/types/user.rs
@@ -1,0 +1,69 @@
+use super::ParseError;
+use std::result::Result;
+use std::str::FromStr;
+
+/// The login name of an IRC user (not the nick). According to RFC 2812:
+///
+/// ```text
+/// user       =  1*( %x01-09 / %x0B-0C / %x0E-1F / %x21-3F / %x41-FF )
+///                 ; any octet except NUL, CR, LF, " " and "@"
+/// ```
+#[derive(PartialEq, Debug)]
+pub struct User(String);
+
+impl FromStr for User {
+    type Err = ParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        if raw.len() < 1 || raw.contains(&['\0', '\r', '\n', ' ', '@'][..]) {
+            Err(ParseError::new("User"))
+        } else {
+            Ok(User(raw.to_string()))
+        }
+    }
+}
+
+impl From<User> for String {
+    fn from(user: User) -> String {
+        user.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::User;
+
+    #[test]
+    fn too_short() {
+        assert!("".parse::<User>().is_err());
+    }
+
+    #[test]
+    fn invalid_chars() {
+        assert!("null\0".parse::<User>().is_err());
+        assert!("carriage\rreturn".parse::<User>().is_err());
+        assert!("line\nfeed".parse::<User>().is_err());
+        assert!(" space".parse::<User>().is_err());
+        assert!("the@sign".parse::<User>().is_err());
+    }
+
+    #[test]
+    fn valid() {
+        assert_eq!(
+            User("a".to_string()),
+            "a".parse::<User>()
+                .expect("1-character string should be accepted.")
+        );
+        assert_eq!(
+            User("potat🥔️".to_string()),
+            "potat🥔️"
+                .parse::<User>()
+                .expect("UTF-8 string should be accepted.")
+        );
+    }
+
+    #[test]
+    fn into_string() {
+        assert_eq!("a".to_string(), String::from(User("a".to_string())));
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,26 +1,8 @@
 mod common;
 
-// > NICK spudly
-// > USER pjohnson local remote :Potato Johnson
-// < :irc.example.net 001 spudly :Welcome to the Internet Relay Network baz!~pjohnson@ircbot_irustc-bot_run_33951ac1d023.ircbot_default
-// < :irc.example.net 002 spudly :Your host is irc.example.net, running version ngircd-23 (x86_64/alpine/linux-musl)
-// < :irc.example.net 003 spudly :This server has been started Fri Aug 21 2020 at 03:21:11 (UTC)
-// < :irc.example.net 004 spudly irc.example.net ngircd-23 abBcCFiIoqrRswx abehiIklmMnoOPqQrRstvVz
-// < :irc.example.net 005 spudly RFC2812 IRCD=ngIRCd CHARSET=UTF-8 CASEMAPPING=ascii PREFIX=(qaohv)~&@%+ CHANTYPES=#&+ CHANMODES=beI,k,l,imMnOPQRstVz CHANLIMIT=#&+:10 :are supported on this server
-// < :irc.example.net 005 spudly CHANNELLEN=50 NICKLEN=9 TOPICLEN=490 AWAYLEN=127 KICKLEN=400 MODES=5 MAXLIST=beI:50 EXCEPTS=e INVEX=I PENALTY :are supported on this server
-// < :irc.example.net 251 spudly :There are 1 users and 0 services on 1 servers
-// < :irc.example.net 254 spudly 1 :channels formed
-// < :irc.example.net 255 spudly :I have 1 users, 0 services and 0 servers
-// < :irc.example.net 265 spudly 1 1 :Current local users: 1, Max: 1
-// < :irc.example.net 266 spudly 1 1 :Current global users: 1, Max: 1
-// < :irc.example.net 250 spudly :Highest connection count: 1 (4 connections received)
-// < :irc.example.net 422 spudly :MOTD file is missing
-
 #[test]
 fn it_authenticates() {
-    let addr = "127.0.0.1:16667";
-
-    let (_client, mut server) = common::init(addr);
+    let (_client, mut server) = common::init("127.0.0.1:16667");
 
     assert_eq!("NICK spudly", server.read_line().expect("Nothing to read."));
     assert_eq!(
@@ -32,10 +14,8 @@ fn it_authenticates() {
 
 #[test]
 fn it_responds_to_ping() {
-    let addr = "127.0.0.1:16667";
+    let (_client, mut server) = common::connect("127.0.0.1:16668");
 
-    let (_client, mut server) = common::init(addr);
-    server.truncate();
     server.write_line("PING :irc.example.com");
 
     assert_eq!(


### PR DESCRIPTION
This implements syntax parsing (`FromStr`/`From<T> for String`) for all components with a syntax outlined in [RFC 2812#2.3.1](https://tools.ietf.org/html/rfc2812#section-2.3.1). Still not an expert, but this seems like a much more idiomatic way of parsing these things.